### PR TITLE
Refactoring

### DIFF
--- a/pkg/botplug/botplug.go
+++ b/pkg/botplug/botplug.go
@@ -1,26 +1,18 @@
 package botplug
 
-import (
-	"time"
-)
+import "github.com/sirupsen/logrus"
 
-type BotPlugin interface {
-	ReceiveMessageEntry(*MessageInput) *MessageOutput
-	ReceiveMemberJoinEntry(*MessageInput) *MessageOutput
+type Config struct {
+	ID     uint
+	Logger *logrus.Logger
 }
 
-type MessageInput struct {
-	Timestamp time.Time
-	Source    *Source
-	Messages  []string
-}
+var id = 0
 
-type Source struct {
-	Type    string
-	UserID  string
-	GroupID string
-}
-
-type MessageOutput struct {
-	Queue []interface{}
+func New(logger *logrus.Logger) Config {
+	id++
+	return Config{
+		ID:     uint(id),
+		Logger: logger,
+	}
 }

--- a/pkg/botplug/line/line.go
+++ b/pkg/botplug/line/line.go
@@ -1,30 +1,41 @@
 package line
 
 import (
-	"log"
-	"net/http"
 	"strings"
 
-	"github.com/line/line-bot-sdk-go/linebot"
-	"github.com/line/line-bot-sdk-go/linebot/httphandler"
-
 	"github.com/ShotaKitazawa/linebot-minecraft/pkg/botplug"
-	"github.com/ShotaKitazawa/linebot-minecraft/pkg/domain"
+	"github.com/line/line-bot-sdk-go/linebot"
+	"github.com/sirupsen/logrus"
 )
 
 type Config struct {
-	domain.LineConfig
-	Plugin botplug.BotPlugin
+	botplug.Config
+	ChannelSecret string
+	ChannelToken  string
+	bot           *linebot.Client
 }
 
-func NewHandler(config *Config) (*httphandler.WebhookHandler, error) {
-	handler, err := httphandler.New(
-		config.ChannelSecret,
-		config.ChannelToken,
-	)
+func New(logger *logrus.Logger, channelSecret, channelToken string, groupIDsStr string) (*BotReceiver, *BotSender, error) {
+	botplugLINEConfig := botplug.New(logger)
+	bot, err := linebot.New(channelSecret, channelToken)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
+	botConfig := Config{
+		Config:        botplugLINEConfig,
+		ChannelSecret: channelSecret,
+		ChannelToken:  channelToken,
+		bot:           bot,
+	}
+	return &BotReceiver{
+			Config: botConfig,
+		}, &BotSender{
+			Config:   botConfig,
+			GroupIDs: strings.Split(groupIDsStr, ","),
+		}, nil
+}
+
+func connect(config Config) (*linebot.Client, error) {
 	bot, err := linebot.New(
 		config.ChannelSecret,
 		config.ChannelToken,
@@ -32,98 +43,6 @@ func NewHandler(config *Config) (*httphandler.WebhookHandler, error) {
 	if err != nil {
 		return nil, err
 	}
+	return bot, nil
 
-	handler.HandleEvents(func(events []*linebot.Event, r *http.Request) {
-		for _, event := range events {
-			switch event.Type {
-			case linebot.EventTypeMessage:
-				switch event.Message.(type) {
-				case *linebot.TextMessage:
-					if err = ReceiveTextMessage(event, bot, config); err != nil {
-						log.Print(err)
-					}
-				}
-			case linebot.EventTypeMemberJoined:
-				if err = ReceiveMemberJoin(event, bot, config); err != nil {
-					log.Print(err)
-				}
-			}
-		}
-	})
-	return handler, nil
-}
-
-func ReceiveTextMessage(event *linebot.Event, bot *linebot.Client, config *Config) (err error) {
-	message := event.Message.(*linebot.TextMessage)
-	input := &botplug.MessageInput{
-		Timestamp: event.Timestamp,
-		Source: &botplug.Source{
-			Type:    string(event.Source.Type),
-			UserID:  event.Source.UserID,
-			GroupID: event.Source.GroupID,
-		},
-		Messages: strings.Fields(message.Text),
-	}
-
-	// execute user function
-	output := config.Plugin.ReceiveMessageEntry(input)
-	if output == nil {
-		return
-	}
-
-	// proceed contents in queue
-	if err := sendQueue(event, bot, config, output); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func ReceiveMemberJoin(event *linebot.Event, bot *linebot.Client, config *Config) (err error) {
-	input := &botplug.MessageInput{
-		Timestamp: event.Timestamp,
-		Source: &botplug.Source{
-			Type:    string(event.Source.Type),
-			UserID:  event.Source.UserID,
-			GroupID: event.Source.GroupID,
-		},
-	}
-
-	// execute user function
-	output := config.Plugin.ReceiveMemberJoinEntry(input)
-	if output == nil {
-		return
-	}
-
-	// proceed contents in queue
-	if err := sendQueue(event, bot, config, output); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func sendQueue(event *linebot.Event, bot *linebot.Client, config *Config, output *botplug.MessageOutput) (err error) {
-	// proceed contents in queue
-	for _, element := range output.Queue {
-		switch typedElement := element.(type) {
-		case string:
-			if _, err = bot.ReplyMessage(event.ReplyToken, linebot.NewTextMessage(typedElement)).Do(); err != nil {
-				return
-			}
-		case []string:
-			if _, err = bot.ReplyMessage(event.ReplyToken, linebot.NewTextMessage(strings.Join(typedElement, ","))).Do(); err != nil {
-				return
-			}
-		case error:
-			if _, err = bot.ReplyMessage(event.ReplyToken, linebot.NewTextMessage(typedElement.Error())).Do(); err != nil {
-				return
-			}
-		case []linebot.SendingMessage:
-			if _, err = bot.ReplyMessage(event.ReplyToken, typedElement...).Do(); err != nil {
-				return
-			}
-		}
-	}
-	return nil
 }

--- a/pkg/botplug/line/receiver.go
+++ b/pkg/botplug/line/receiver.go
@@ -1,0 +1,131 @@
+package line
+
+import (
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/line/line-bot-sdk-go/linebot"
+	"github.com/line/line-bot-sdk-go/linebot/httphandler"
+
+	"github.com/ShotaKitazawa/linebot-minecraft/pkg/botplug"
+)
+
+type BotReceiver struct {
+	Config
+	Plugin botplug.BotPluginReceiver
+}
+
+func (receiver *BotReceiver) WithPlugin(plugin botplug.BotPluginReceiver) *BotReceiver {
+	result := receiver
+	result.Plugin = plugin
+	return result
+}
+
+func (receiver *BotReceiver) NewHandler() (*httphandler.WebhookHandler, error) {
+	handler, err := httphandler.New(
+		receiver.ChannelSecret,
+		receiver.ChannelToken,
+	)
+	if err != nil {
+		return nil, err
+	}
+	receiver.bot, err = connect(receiver.Config)
+	if err != nil {
+		return nil, err
+	}
+
+	handler.HandleEvents(func(events []*linebot.Event, r *http.Request) {
+		for _, event := range events {
+			switch event.Type {
+			case linebot.EventTypeMessage:
+				switch event.Message.(type) {
+				case *linebot.TextMessage:
+					if err = receiver.ReceiveTextMessage(event); err != nil {
+						log.Print(err)
+					}
+				}
+			case linebot.EventTypeMemberJoined:
+				if err = receiver.ReceiveMemberJoin(event); err != nil {
+					log.Print(err)
+				}
+			}
+		}
+	})
+	return handler, nil
+}
+
+func (receiver *BotReceiver) ReceiveTextMessage(event *linebot.Event) (err error) {
+	message := event.Message.(*linebot.TextMessage)
+	input := &botplug.MessageInput{
+		Timestamp: event.Timestamp,
+		Source: &botplug.Source{
+			Type:    string(event.Source.Type),
+			UserID:  event.Source.UserID,
+			GroupID: event.Source.GroupID,
+		},
+		Messages: strings.Fields(message.Text),
+	}
+
+	// execute user function
+	output := receiver.Plugin.ReceiveMessageEntry(input)
+	if output == nil {
+		return
+	}
+
+	// proceed contents in queue
+	if err := receiver.sendQueue(event, receiver.bot, output); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (receiver *BotReceiver) ReceiveMemberJoin(event *linebot.Event) (err error) {
+	input := &botplug.MessageInput{
+		Timestamp: event.Timestamp,
+		Source: &botplug.Source{
+			Type:    string(event.Source.Type),
+			UserID:  event.Source.UserID,
+			GroupID: event.Source.GroupID,
+		},
+	}
+
+	// execute user function
+	output := receiver.Plugin.ReceiveMemberJoinEntry(input)
+	if output == nil {
+		return
+	}
+
+	// proceed contents in queue
+	if err := receiver.sendQueue(event, receiver.bot, output); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (receiver *BotReceiver) sendQueue(event *linebot.Event, bot *linebot.Client, output *botplug.MessageOutput) (err error) {
+	// proceed contents in queue
+	for _, element := range output.Queue {
+		switch typedElement := element.(type) {
+		case string:
+			if _, err = bot.ReplyMessage(event.ReplyToken, linebot.NewTextMessage(typedElement)).Do(); err != nil {
+				return
+			}
+		case []string:
+			if _, err = bot.ReplyMessage(event.ReplyToken, linebot.NewTextMessage(strings.Join(typedElement, ","))).Do(); err != nil {
+				return
+			}
+		case error:
+			if _, err = bot.ReplyMessage(event.ReplyToken, linebot.NewTextMessage(typedElement.Error())).Do(); err != nil {
+				return
+			}
+		case []linebot.SendingMessage:
+			if _, err = bot.ReplyMessage(event.ReplyToken, typedElement...).Do(); err != nil {
+				return
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/botplug/line/sender.go
+++ b/pkg/botplug/line/sender.go
@@ -1,0 +1,20 @@
+package line
+
+import (
+	"github.com/line/line-bot-sdk-go/linebot"
+)
+
+type BotSender struct {
+	Config
+	GroupIDs []string
+}
+
+func (sender *BotSender) SendTextMessage(text string) (err error) {
+	for _, groupID := range sender.GroupIDs {
+		if _, err := sender.bot.PushMessage(groupID, linebot.NewTextMessage(text)).Do(); err != nil {
+			sender.Logger.Error(`failed to push notification: `, err)
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/botplug/receiver.go
+++ b/pkg/botplug/receiver.go
@@ -1,0 +1,24 @@
+package botplug
+
+import "time"
+
+type BotPluginReceiver interface {
+	ReceiveMessageEntry(*MessageInput) *MessageOutput
+	ReceiveMemberJoinEntry(*MessageInput) *MessageOutput
+}
+
+type MessageInput struct {
+	Timestamp time.Time
+	Source    *Source
+	Messages  []string
+}
+
+type Source struct {
+	Type    string
+	UserID  string
+	GroupID string
+}
+
+type MessageOutput struct {
+	Queue []interface{}
+}

--- a/pkg/botplug/sender.go
+++ b/pkg/botplug/sender.go
@@ -1,0 +1,5 @@
+package botplug
+
+type BotPluginSender interface {
+	SendTextMessage(string) error
+}

--- a/pkg/eventer/eventer.go
+++ b/pkg/eventer/eventer.go
@@ -22,11 +22,11 @@ type Eventer struct {
 
 	MinecraftHostname string
 	sharedMem         sharedmem.SharedMem
-	rcon              *rcon.Client
+	rcon              rcon.RconClient
 	Logger            *logrus.Logger
 }
 
-func New(minecraftHostname string, lineConfig domain.LineConfig, m sharedmem.SharedMem, rcon *rcon.Client, logger *logrus.Logger) (*Eventer, error) {
+func New(minecraftHostname string, lineConfig domain.LineConfig, m sharedmem.SharedMem, rcon rcon.RconClient, logger *logrus.Logger) (*Eventer, error) {
 	client, err := linebot.New(lineConfig.ChannelSecret, lineConfig.ChannelToken)
 	if err != nil {
 		return nil, err

--- a/pkg/eventer/eventer_test.go
+++ b/pkg/eventer/eventer_test.go
@@ -1,0 +1,33 @@
+package eventer
+
+/*
+import (
+	"testing"
+
+	"github.com/ShotaKitazawa/linebot-minecraft/pkg/domain"
+)
+
+func TestEventer(t *testing.T) {
+	sharedMemValid := &sharedmemMockValid{}
+	New("test", domain.LineConfig{}, sharedMemValid)
+}
+
+type sharedmemMockValid struct {
+	data domain.Entity
+}
+
+func (m *sharedmemMockValid) SyncReadEntityFromSharedMem() (*domain.Entity, error) {
+	return &domain.Entity{
+		AllUsers:           []domain.User{},
+		LoginUsers:         []domain.User{},
+		LogoutUsers:        []domain.User{},
+		WhitelistUsernames: []string{},
+	}, nil
+}
+
+func (m *sharedmemMockValid) AsyncWriteEntityToSharedMem(data domain.Entity) error {
+	m.data = data
+	return nil
+}
+
+*/

--- a/pkg/rcon/interfaces.go
+++ b/pkg/rcon/interfaces.go
@@ -1,0 +1,10 @@
+package rcon
+
+type RconClient interface {
+	List() ([]string, error)
+	WhitelistAdd(string) error
+	WhitelistRemove(string) error
+	WhitelistList() ([]string, error)
+	DataGetEntity(string) (*User, error)
+	Title(string) ([]string, error)
+}


### PR DESCRIPTION
* `pkg/rcon` 呼び出しを interface 越しになるよう修正
* eventer に持たせるインスタンスを LINE Client > BotPluginSender interface に変更
    * eventer から LINE に push 通知する際は BotPluginSender interface 越しに呼び出し
        * eventer から LINE 以外への push 通知の実装がやりやすくなった